### PR TITLE
Remove welcome comments from Authy controller

### DIFF
--- a/app/Http/Controllers/Auth/AuthyController.php
+++ b/app/Http/Controllers/Auth/AuthyController.php
@@ -9,16 +9,6 @@ use App\Http\Requests;
 
 class AuthyController extends Controller {
 
-	/*
-	|--------------------------------------------------------------------------
-	| Welcome Controller
-	|--------------------------------------------------------------------------
-	|
-	| This controller renders the "marketing page" for the application and
-	| is configured to only allow guests. Like most of the other sample
-	| controllers, you are free to modify or remove it as you desire.
-	|
-	*/
 
 	/**
 	 * Create a new controller instance.


### PR DESCRIPTION
Comments describing the welcome controller were left in here when copying the welcome controller as a template for Authy controller.
